### PR TITLE
Use uvx in fraim.py instead of uv run

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,11 +98,6 @@ runs:
         cd ${{ github.action_path }}
         uv sync
 
-    - name: Get Fraim v0.7.0
-      shell: bash
-      run: |
-        uv tool install fraim==v0.7.0
-
     - name: Create GitHub App Token
       id: github-app-token
       if: ${{ inputs.github-app-id && inputs.github-app-private-key }}

--- a/src/fraim.py
+++ b/src/fraim.py
@@ -130,7 +130,7 @@ def main() -> None:
     print(f"Running workflow: {workflow}")
 
     # Build the complete command: uv run fraim run [workflow] [global_args] [workflow_args]
-    cmd = ['uv', 'run', 'fraim', 'run', workflow] + global_args + workflow_cli_args
+    cmd = ['uvx', 'fraim==v0.7.0', 'run', workflow] + global_args + workflow_cli_args
 
     print(f"Running: {' '.join(cmd)}")
     print(f"Working directory: {os.getcwd()}")


### PR DESCRIPTION
When using the fraim-action inside the fraim repo itself, `uv run ..` will run the current code inside fraim, instead of the version specified by `uv tool install`. To fix this, we can just use `uvx fraim==<version>` directly to avoid conflicts in version of fraim sitting locally on the machine.